### PR TITLE
Use proper usize type for lengths

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@v2.0.1
         with:
-          version: 0.11.0-dev.3322+82632aff2
+          version: 0.11.0
 
       - name: Run zigSelf tests
         run: zig build test

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ You need the Zig compiler, preferably one built with the known-good version
 commit. You can find the source code, instructions for building, and more on the
 [Zig repository](https://github.com/ziglang/zig).
 
-Latest Zig commit known to work is [`82632aff2`](https://github.com/ziglang/zig/commit/82632aff2).
+Latest Zig commit known to work is [`67709b6`](https://github.com/ziglang/zig/commit/67709b638224ac03820226c6744d8b6ead59184c)
+which is the official `0.11.0` release.
 Earlier and later versions may work but there are no guarantees.
 
 ## Building zigSelf

--- a/src/language/ast_printer.zig
+++ b/src/language/ast_printer.zig
@@ -250,7 +250,7 @@ pub fn dumpString(self: *Self, string: AST.StringNode) void {
     self.indent();
 
     self.setStem(.Last);
-    self.print("content: \"{s}", .{string.value[0..std.math.min(200, string.value.len)]});
+    self.print("content: \"{s}", .{string.value[0..@min(200, string.value.len)]});
     if (string.value.len > 200) {
         std.debug.print("...", .{});
     }

--- a/src/language/parser.zig
+++ b/src/language/parser.zig
@@ -1223,7 +1223,7 @@ fn parseFloatingPoint(self: *Self) ParseError!AST.NumberNode {
         switch (state) {
             .Integer => switch (c) {
                 '0'...'9' => {
-                    result = (result * 10) + @intToFloat(f64, c - '0');
+                    result = (result * 10) + @as(f64, @floatFromInt(c - '0'));
                 },
                 '.' => {
                     state = .Fraction;
@@ -1246,8 +1246,8 @@ fn parseFloatingPoint(self: *Self) ParseError!AST.NumberNode {
         }
     }
 
-    var divisor = std.math.pow(f64, 10.0, @intToFloat(f64, fraction_counter));
-    result += @intToFloat(f64, fraction) / divisor;
+    var divisor = std.math.pow(f64, 10.0, @as(f64, @floatFromInt(fraction_counter)));
+    result += @as(f64, @floatFromInt(fraction)) / divisor;
 
     const node = AST.NumberNode{
         .value = .{ .FloatingPoint = result },

--- a/src/runtime/Activation.zig
+++ b/src/runtime/Activation.zig
@@ -152,9 +152,9 @@ pub const ActivationStack = struct {
         }
 
         const current_activation = self.getCurrent();
-        std.debug.assert(@ptrToInt(current_activation) >= @ptrToInt(activation));
+        std.debug.assert(@intFromPtr(current_activation) >= @intFromPtr(activation));
 
-        const distance = @divExact(@ptrToInt(current_activation) - @ptrToInt(activation), @sizeOf(Self));
+        const distance = @divExact(@intFromPtr(current_activation) - @intFromPtr(activation), @sizeOf(Self));
         var current_depth = self.getDepth();
         const target_depth = current_depth - distance;
         while (current_depth != target_depth) : (current_depth -= 1) {
@@ -190,15 +190,15 @@ pub const ActivationStack = struct {
         const start_of_slice = self.stack.items.ptr;
         const end_of_slice = start_of_slice + self.stack.items.len;
 
-        return @ptrToInt(activation) >= @ptrToInt(start_of_slice) and
-            @ptrToInt(activation) < @ptrToInt(end_of_slice);
+        return @intFromPtr(activation) >= @intFromPtr(start_of_slice) and
+            @intFromPtr(activation) < @intFromPtr(end_of_slice);
     }
 
     pub fn offsetOf(self: ActivationStack, activation: *Self) usize {
         std.debug.assert(self.isActivationWithin(activation));
 
         const start_of_slice = self.stack.items.ptr;
-        return @divExact(@ptrToInt(activation) - @ptrToInt(start_of_slice), @sizeOf(Self));
+        return @divExact(@intFromPtr(activation) - @intFromPtr(start_of_slice), @sizeOf(Self));
     }
 
     pub fn pushEntrypointActivation(self: *ActivationStack, vm: *VirtualMachine, new_executable: bytecode.Executable.Ref) !void {
@@ -247,13 +247,13 @@ pub const ActivationRef = packed struct {
 
     pub fn init(activation: *Self, stack: ActivationStack) ActivationRef {
         return .{
-            .offset = IntegerValue(.Unsigned).init(@intCast(u64, stack.offsetOf(activation))),
+            .offset = IntegerValue(.Unsigned).init(@intCast(stack.offsetOf(activation))),
             .saved_id = IntegerValue(.Unsigned).init(activation.activation_id),
         };
     }
 
     fn getPointer(self: ActivationRef, stack: ActivationStack) *Self {
-        return &stack.stack.items[@intCast(usize, self.offset.get())];
+        return &stack.stack.items[@intCast(self.offset.get())];
     }
 
     pub fn isAlive(self: ActivationRef, stack: ActivationStack) bool {

--- a/src/runtime/ByteArray.zig
+++ b/src/runtime/ByteArray.zig
@@ -22,7 +22,7 @@ pub fn createFromString(token: *Heap.AllocationToken, string: []const u8) Self {
 
 pub fn createUninitialized(token: *Heap.AllocationToken, size: usize) Self {
     var memory_area = token.allocate(.ByteArray, requiredSizeForAllocation(size));
-    var header = @ptrCast(Header.Ptr, memory_area);
+    var header: Header.Ptr = @ptrCast(memory_area);
 
     header.init(size);
 
@@ -30,22 +30,23 @@ pub fn createUninitialized(token: *Heap.AllocationToken, size: usize) Self {
 }
 
 pub inline fn fromAddress(address: [*]u64) Self {
-    return .{ .header = @ptrCast(*align(@alignOf(u64)) Header, address) };
+    return .{ .header = @ptrCast(address) };
 }
 
 pub fn getValues(self: Self) []u8 {
     const header_size = @sizeOf(Header);
-    const total_length = self.header.length.get();
+    const total_length: usize = @intCast(self.header.length.get());
 
-    return @ptrCast([*]u8, self.header)[header_size..@intCast(usize, total_length)];
+    const header: [*]u8 = @ptrCast(self.header);
+    return header[header_size..total_length];
 }
 
 pub fn getLength(self: Self) usize {
-    return @intCast(usize, self.header.length.get() - @sizeOf(Header));
+    return @intCast(self.header.length.get() - @sizeOf(Header));
 }
 
 pub fn asValue(self: Self) Value {
-    return Value.fromObjectAddress(@ptrCast([*]u64, @alignCast(@alignOf(u64), self.header)));
+    return Value.fromObjectAddress(@ptrCast(@alignCast(self.header)));
 }
 
 pub fn getSizeInMemory(self: Self) usize {
@@ -73,6 +74,6 @@ pub const Header = packed struct {
     }
 
     pub fn asByteVector(self: Header.Ptr) Self {
-        return .{ .header = @alignCast(@alignOf(u64), self) };
+        return .{ .header = @alignCast(self) };
     }
 };

--- a/src/runtime/bytecode/astcode/Liveness.zig
+++ b/src/runtime/bytecode/astcode/Liveness.zig
@@ -45,7 +45,7 @@ fn addIntervalForRegister(self: *Liveness, allocator: Allocator, location: astco
         }
     }
 
-    try self.intervals.append(allocator, .{ .start = @intCast(u32, start), .end = @intCast(u32, end) });
+    try self.intervals.append(allocator, .{ .start = @intCast(start), .end = @intCast(end) });
 }
 
 fn instructionReferencesRegister(inst: astcode.Instruction, location: astcode.RegisterLocation) bool {

--- a/src/runtime/bytecode/astcode/register_location.zig
+++ b/src/runtime/bytecode/astcode/register_location.zig
@@ -27,11 +27,11 @@ pub const RegisterLocation = enum(u32) {
     }
 
     pub fn fromIndexAllowNil(index: u32) RegisterLocation {
-        return @intToEnum(RegisterLocation, index);
+        return @enumFromInt(index);
     }
 
     pub fn registerOffset(self: RegisterLocation) u32 {
-        const offset = @enumToInt(self);
+        const offset = @intFromEnum(self);
         std.debug.assert(offset > 0);
         return offset - 1;
     }
@@ -44,6 +44,6 @@ pub const RegisterLocation = enum(u32) {
     ) !void {
         _ = fmt;
         try writer.writeByte('%');
-        try std.fmt.formatInt(@enumToInt(loc), 10, .lower, options, writer);
+        try std.fmt.formatInt(@intFromEnum(loc), 10, .lower, options, writer);
     }
 };

--- a/src/runtime/bytecode/block.zig
+++ b/src/runtime/bytecode/block.zig
@@ -107,8 +107,8 @@ fn Block(comptime InstructionT: type, comptime access_mode: AccessMode) type {
             try self.instructions.append(allocator, undefined);
 
             return switch (access_mode) {
-                .ByField => @intCast(u32, self.instructions.len - 1),
-                .ByInstruction => @intCast(u32, self.instructions.items.len - 1),
+                .ByField => @intCast(self.instructions.len - 1),
+                .ByInstruction => @intCast(self.instructions.items.len - 1),
             };
         }
 

--- a/src/runtime/bytecode/executable.zig
+++ b/src/runtime/bytecode/executable.zig
@@ -58,7 +58,7 @@ fn Executable(comptime BlockT: type) type {
             const block_index = self.blocks.items.len;
             try self.blocks.append(self.allocator, block);
 
-            return @intCast(u32, block_index);
+            return @intCast(block_index);
         }
 
         pub fn getBlock(self: *Self, index: u32) *Block {

--- a/src/runtime/bytecode/lowcode/RegisterPool.zig
+++ b/src/runtime/bytecode/lowcode/RegisterPool.zig
@@ -63,7 +63,7 @@ pub fn allocateRegister(
 
     self.clobbered_registers.set(free_register.?);
     // FIXME: Remove manual register number adjustment!
-    const register = LowcodeRegisterLocation.fromInt(@intCast(u32, free_register.? + 2));
+    const register = LowcodeRegisterLocation.fromInt(@intCast(free_register.? + 2));
     try self.insertActiveInterval(allocator, register, interval);
     try self.allocated_registers.put(allocator, ast_register, register);
 

--- a/src/runtime/error.zig
+++ b/src/runtime/error.zig
@@ -21,7 +21,7 @@ fn writeTraceForFrame(message_name: []const u8, source_range: SourceRange) void 
 
     writer.writeByteNTimes(' ', range.start.column - 1) catch unreachable;
     if (range.start.line == range.end.line) {
-        writer.writeByteNTimes('^', std.math.max(1, range.end.column - range.start.column)) catch unreachable;
+        writer.writeByteNTimes('^', @max(1, range.end.column - range.start.column)) catch unreachable;
     } else {
         writer.writeByteNTimes('^', source_line.len - range.start.column + 1) catch unreachable;
         writer.writeByteNTimes('.', 3) catch unreachable;
@@ -39,9 +39,9 @@ pub fn printTraceFromActivationStackUntil(stack: []Activation, first_source_rang
 
     var called_from = first_source_range;
 
-    var i = @intCast(isize, stack.len - 1);
+    var i: isize = @intCast(stack.len - 1);
     while (i >= 0) : (i -= 1) {
-        const activation_ptr = &stack[@intCast(usize, i)];
+        const activation_ptr = &stack[@intCast(i)];
 
         if (until) |until_ptr| {
             if (until_ptr == activation_ptr) break;

--- a/src/runtime/interpreter.zig
+++ b/src/runtime/interpreter.zig
@@ -91,7 +91,7 @@ pub const InterpreterContext = struct {
 };
 
 pub fn execute(context: *InterpreterContext) InterpreterError!ExecutionResult {
-    try specialized_executors[@enumToInt(context.block.getOpcode(context.instructionIndex()))](context);
+    try specialized_executors[@intFromEnum(context.block.getOpcode(context.instructionIndex()))](context);
     return context.result.?;
 }
 
@@ -152,7 +152,7 @@ pub fn executeSpecialized(comptime opcode: bytecode.Instruction.Opcode) OpcodeHa
             if (context.result != null) return;
 
             const new_index = context.activation.advanceInstruction();
-            return @call(.always_tail, specialized_executors[@enumToInt(context.block.getOpcode(new_index))], .{context});
+            return @call(.always_tail, specialized_executors[@intFromEnum(context.block.getOpcode(new_index))], .{context});
         }
     }.execute;
 }
@@ -316,7 +316,7 @@ fn opcodePushRegisters(context: *InterpreterContext) InterpreterError!void {
     var iterator = context.block.getTypedPayload(context.instructionIndex(), .PushRegisters).iterator(.{});
     while (iterator.next()) |clobbered_register| {
         // FIXME: Remove manual register number adjustment!
-        const register = bytecode.RegisterLocation.fromInt(@intCast(u32, clobbered_register + 2));
+        const register = bytecode.RegisterLocation.fromInt(@intCast(clobbered_register + 2));
         try context.actor.saved_register_stack.push(context.vm.allocator, .{ .register = register, .value = context.vm.readRegister(register) });
     }
 }
@@ -576,7 +576,7 @@ fn executeBlock(
     target_location: bytecode.RegisterLocation,
     source_range: SourceRange,
 ) !void {
-    const message_name = try vm.getOrCreateBlockMessageName(@intCast(u8, arguments.len));
+    const message_name = try vm.getOrCreateBlockMessageName(@intCast(arguments.len));
     var block = block_receiver;
 
     var required_memory = ActivationObject.requiredSizeForAllocation(
@@ -688,7 +688,7 @@ fn createObject(
     var total_assignable_slot_count: u8 = 0;
     for (slots, 0..) |slot, i| {
         total_slot_count += slot.requiredSlotSpace(slots[0..i]);
-        total_assignable_slot_count += @intCast(u8, slot.requiredAssignableSlotValueSpace(slots[0..i]));
+        total_assignable_slot_count += @intCast(slot.requiredAssignableSlotValueSpace(slots[0..i]));
     }
 
     var token = try vm.heap.getAllocation(
@@ -726,7 +726,7 @@ fn createMethod(
     var argument_slot_count: u8 = 0;
     for (slots, 0..) |slot, i| {
         total_slot_count += slot.requiredSlotSpace(slots[0..i]);
-        total_assignable_slot_count += @intCast(u8, slot.requiredAssignableSlotValueSpace(slots[0..i]));
+        total_assignable_slot_count += @intCast(slot.requiredAssignableSlotValueSpace(slots[0..i]));
 
         // FIXME: This makes the assumption that argument slots are
         //        never overwritten.
@@ -777,7 +777,7 @@ fn createBlock(
     var argument_slot_count: u8 = 0;
     for (slots, 0..) |slot, i| {
         total_slot_count += slot.requiredSlotSpace(slots[0..i]);
-        total_assignable_slot_count += @intCast(u8, slot.requiredAssignableSlotValueSpace(slots[0..i]));
+        total_assignable_slot_count += @intCast(slot.requiredAssignableSlotValueSpace(slots[0..i]));
 
         // FIXME: This makes the assumption that argument slots are
         //        never overwritten.

--- a/src/runtime/intrinsic_map.zig
+++ b/src/runtime/intrinsic_map.zig
@@ -71,7 +71,7 @@ pub fn IntrinsicMap(comptime MapT: type, comptime object_type: ObjectType) type 
         // defined by the user.
 
         pub fn asAddress(self: Ptr) [*]u64 {
-            return @ptrCast([*]u64, self);
+            return @ptrCast(self);
         }
 
         pub fn asValue(self: Ptr) value.Value {
@@ -130,7 +130,7 @@ fn IntrinsicObject(comptime MapT: type, comptime field_names: []const []const u8
 
         pub fn create(token: *Heap.AllocationToken, map: MapT.Ptr, actor_id: u31) Ptr {
             const memory = token.allocate(.Object, requiredSizeForAllocation());
-            const self = @ptrCast(Ptr, memory);
+            const self: Ptr = @ptrCast(memory);
 
             self.init(map, actor_id);
             return self;
@@ -147,7 +147,7 @@ fn IntrinsicObject(comptime MapT: type, comptime field_names: []const []const u8
         }
 
         pub fn asAddress(self: Ptr) [*]u64 {
-            return @ptrCast([*]u64, self);
+            return @ptrCast(self);
         }
 
         pub fn asValue(self: Ptr) value.Value {
@@ -155,7 +155,7 @@ fn IntrinsicObject(comptime MapT: type, comptime field_names: []const []const u8
         }
 
         pub fn getMap(self: Ptr) MapT.Ptr {
-            return @ptrCast(MapT.Ptr, self.object.map.asObject().mustBeType(.Map));
+            return @ptrCast(self.object.map.asObject().mustBeType(.Map));
         }
 
         pub fn getSizeInMemory(self: Ptr) usize {

--- a/src/runtime/map_builder.zig
+++ b/src/runtime/map_builder.zig
@@ -58,7 +58,7 @@ pub fn MapBuilder(comptime MapType: type, comptime ObjectType: type) type {
             // NOTE: Method and block maps do not count the argument slot count
             //       towards their assignable slot counts, because the argument
             //       slot values don't exist on the method and block objects.
-            self.map.setAssignableSlotCount(@intCast(u8, self.assignable_slot_index));
+            self.map.setAssignableSlotCount(@intCast(self.assignable_slot_index));
         }
 
         pub fn createObject(self: *Self, current_actor_id: u31) ObjectType.Ptr {

--- a/src/runtime/object_bless.zig
+++ b/src/runtime/object_bless.zig
@@ -29,7 +29,7 @@ fn calculateRequiredMemoryForBlessing(allocator: Allocator, value: Value) Alloca
 
             return object;
         }
-    }.f) catch |err| return @errSetCast(Allocator.Error, err);
+    }.f) catch |err| return @as(Allocator.Error, @errSetCast(err));
 
     return required_memory;
 }
@@ -52,7 +52,7 @@ fn copyObjectGraphForNewActor(vm: *VirtualMachine, token: *Heap.AllocationToken,
             gop.value_ptr.* = new_object.getAddress();
             return new_object;
         }
-    }.f) catch |err| return @errSetCast(Allocator.Error, err);
+    }.f) catch |err| return @as(Allocator.Error, @errSetCast(err));
 }
 
 pub fn bless(vm: *VirtualMachine, heap: *Heap, actor_id: u31, const_value: Value) !Value {

--- a/src/runtime/objects/activation.zig
+++ b/src/runtime/objects/activation.zig
@@ -20,6 +20,7 @@ const value_import = @import("../value.zig");
 const object_lookup = @import("../object_lookup.zig");
 const stage2_compat = @import("../../utility/stage2_compat.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
+const exceedsBoundsOf = @import("../../utility/bounds_check.zig").exceedsBoundsOf;
 const SlotsLikeObjectBase = slots.SlotsLikeObjectBase;
 
 /// An activation object, which is just a slots object but with an extra
@@ -186,7 +187,10 @@ pub const Activation = extern struct {
     pub fn getAssignableSlotValue(self: Activation.Ptr, slot: Slot) *GenericValue {
         std.debug.assert(slot.isAssignable());
 
-        const offset: usize = @intCast(slot.value.asUnsignedInteger());
+        const offset_int = slot.value.asUnsignedInteger();
+        std.debug.assert(!exceedsBoundsOf(offset_int, usize));
+
+        const offset: usize = @intCast(offset_int);
         return if (slot.isArgument())
             &self.getArgumentSlots()[offset]
         else

--- a/src/runtime/objects/actor.zig
+++ b/src/runtime/objects/actor.zig
@@ -35,7 +35,7 @@ pub const Actor = extern struct {
 
     pub fn create(map_map: Map.Ptr, token: *Heap.AllocationToken, genesis_actor_id: u31, actor: *VMActor, context: GenericValue) !Actor.Ptr {
         const memory_area = token.allocate(.Object, requiredSizeForAllocation());
-        const self = @ptrCast(Actor.Ptr, memory_area);
+        const self: Actor.Ptr = @ptrCast(memory_area);
         self.init(genesis_actor_id, map_map, actor, context);
 
         try token.heap.markAddressAsNeedingFinalization(memory_area);
@@ -55,7 +55,7 @@ pub const Actor = extern struct {
     }
 
     pub fn asObjectAddress(self: Actor.Ptr) [*]u64 {
-        return @ptrCast([*]u64, @alignCast(@alignOf(u64), self));
+        return @ptrCast(@alignCast(self));
     }
 
     pub fn asValue(self: Actor.Ptr) GenericValue {

--- a/src/runtime/objects/actor_proxy.zig
+++ b/src/runtime/objects/actor_proxy.zig
@@ -31,7 +31,7 @@ pub const ActorProxy = extern struct {
     /// Create the Actor object without sending a message to it.
     pub fn create(map_map: Map.Ptr, token: *Heap.AllocationToken, current_actor_id: u31, actor_object: Actor.Ptr) ActorProxy.Ptr {
         const memory_area = token.allocate(.Object, requiredSizeForAllocation());
-        const self = @ptrCast(ActorProxy.Ptr, memory_area);
+        const self: ActorProxy.Ptr = @ptrCast(memory_area);
         self.init(current_actor_id, map_map, actor_object);
         return self;
     }
@@ -48,7 +48,7 @@ pub const ActorProxy = extern struct {
     }
 
     pub fn asObjectAddress(self: ActorProxy.Ptr) [*]u64 {
-        return @ptrCast([*]u64, @alignCast(@alignOf(u64), self));
+        return @ptrCast(@alignCast(self));
     }
 
     pub fn asValue(self: ActorProxy.Ptr) GenericValue {

--- a/src/runtime/objects/array.zig
+++ b/src/runtime/objects/array.zig
@@ -39,7 +39,7 @@ pub const Array = extern struct {
         const size = requiredSizeForAllocation(map.getSize());
 
         var memory_area = token.allocate(.Object, size);
-        var self = @ptrCast(Array.Ptr, memory_area);
+        var self: Array.Ptr = @ptrCast(memory_area);
         self.init(actor_id, map, values, filler);
 
         return self;
@@ -54,7 +54,7 @@ pub const Array = extern struct {
             .map = map.asValue(),
         };
 
-        const values_to_copy = values[0..std.math.min(values.len, map.getSize())];
+        const values_to_copy = values[0..@min(values.len, map.getSize())];
         @memcpy(self.getValues()[0..values_to_copy.len], values_to_copy);
 
         if (map.getSize() > values.len) {
@@ -63,7 +63,7 @@ pub const Array = extern struct {
     }
 
     pub fn asObjectAddress(self: Array.Ptr) [*]u64 {
-        return @ptrCast([*]u64, @alignCast(@alignOf(u64), self));
+        return @ptrCast(@alignCast(self));
     }
 
     pub fn asValue(self: Array.Ptr) GenericValue {
@@ -102,10 +102,10 @@ pub const Array = extern struct {
     }
 
     pub fn getValues(self: Array.Ptr) []GenericValue {
-        const object_memory = @ptrCast([*]u8, self);
+        const object_memory: [*]u8 = @ptrCast(self);
         const start_of_items = object_memory + @sizeOf(Array);
 
-        return std.mem.bytesAsSlice(GenericValue, start_of_items[0 .. self.getSize() * @sizeOf(GenericValue)]);
+        return @alignCast(std.mem.bytesAsSlice(GenericValue, start_of_items[0 .. self.getSize() * @sizeOf(GenericValue)]));
     }
 
     pub fn clone(self: Array.Ptr, vm: *VirtualMachine, token: *Heap.AllocationToken, actor_id: u31) Array.Ptr {
@@ -141,7 +141,7 @@ pub const ArrayMap = extern struct {
         const memory_size = requiredSizeForAllocation();
 
         var memory_area = token.allocate(.Object, memory_size);
-        var self = @ptrCast(ArrayMap.Ptr, memory_area);
+        var self: ArrayMap.Ptr = @ptrCast(memory_area);
         self.init(map_map, size);
 
         return self;
@@ -153,11 +153,11 @@ pub const ArrayMap = extern struct {
     }
 
     pub fn asValue(self: ArrayMap.Ptr) GenericValue {
-        return GenericValue.fromObjectAddress(@ptrCast([*]u64, @alignCast(@alignOf(u64), self)));
+        return GenericValue.fromObjectAddress(@ptrCast(@alignCast(self)));
     }
 
     pub fn getSize(self: ArrayMap.Ptr) usize {
-        return @intCast(usize, self.size.get());
+        return @intCast(self.size.get());
     }
 
     pub fn getSizeInMemory(self: ArrayMap.Ptr) usize {

--- a/src/runtime/objects/block.zig
+++ b/src/runtime/objects/block.zig
@@ -46,10 +46,10 @@ pub const Block = extern struct {
             );
         }
 
-        const size = Block.requiredSizeForAllocation(@intCast(u8, assignable_slot_values.len));
+        const size = Block.requiredSizeForAllocation(@intCast(assignable_slot_values.len));
 
         var memory_area = token.allocate(.Object, size);
-        var self = @ptrCast(Block.Ptr, memory_area);
+        var self: Block.Ptr = @ptrCast(memory_area);
         self.init(actor_id, map);
         @memcpy(self.getAssignableSlots(), assignable_slot_values);
 
@@ -194,7 +194,7 @@ pub const BlockMap = extern struct {
         const size = BlockMap.requiredSizeForAllocation(total_slot_count);
 
         var memory_area = token.allocate(.Object, size);
-        var self = @ptrCast(BlockMap.Ptr, memory_area);
+        var self: BlockMap.Ptr = @ptrCast(memory_area);
         self.init(map_map, argument_slot_count, total_slot_count, parent_activation, nonlocal_return_target_activation, block, executable);
 
         try token.heap.markAddressAsNeedingFinalization(memory_area);

--- a/src/runtime/objects/byte_array.zig
+++ b/src/runtime/objects/byte_array.zig
@@ -43,7 +43,7 @@ pub const ByteArray = extern struct {
     pub fn create(map_map: Map.Ptr, token: *Heap.AllocationToken, actor_id: u31, byte_array: VMByteArray) ByteArray.Ptr {
         const size = requiredSizeForSelfAllocation();
         var memory_area = token.allocate(.Object, size);
-        var self = @ptrCast(ByteArray.Ptr, memory_area);
+        var self: ByteArray.Ptr = @ptrCast(memory_area);
         self.init(actor_id, map_map, byte_array);
 
         return self;
@@ -61,7 +61,7 @@ pub const ByteArray = extern struct {
     }
 
     pub fn asObjectAddress(self: ByteArray.Ptr) [*]u64 {
-        return @ptrCast([*]u64, @alignCast(@alignOf(u64), self));
+        return @ptrCast(@alignCast(self));
     }
 
     pub fn asValue(self: ByteArray.Ptr) GenericValue {

--- a/src/runtime/objects/byte_array.zig
+++ b/src/runtime/objects/byte_array.zig
@@ -72,7 +72,7 @@ pub const ByteArray = extern struct {
         return self.getByteArray().getValues();
     }
 
-    pub fn getLength(self: ByteArray.Ptr) u64 {
+    pub fn getLength(self: ByteArray.Ptr) usize {
         return self.getByteArray().getLength();
     }
 

--- a/src/runtime/objects/executable_map.zig
+++ b/src/runtime/objects/executable_map.zig
@@ -62,10 +62,12 @@ pub const ExecutableMap = extern struct {
     }
 
     pub fn getArgumentSlotCount(self: ExecutableMap.Ptr) u8 {
-        return @ptrCast(*ExecutableInformation, &self.slots.information.extra).argument_slot_count;
+        const executable_information: *ExecutableInformation = @ptrCast(&self.slots.information.extra);
+        return executable_information.argument_slot_count;
     }
 
     fn setArgumentSlotCount(self: ExecutableMap.Ptr, count: u8) void {
-        @ptrCast(*ExecutableInformation, &self.slots.information.extra).argument_slot_count = count;
+        const executable_information: *ExecutableInformation = @ptrCast(&self.slots.information.extra);
+        executable_information.argument_slot_count = count;
     }
 };

--- a/src/runtime/objects/intrinsic/addrinfo.zig
+++ b/src/runtime/objects/intrinsic/addrinfo.zig
@@ -25,7 +25,7 @@ pub const AddrInfoMap = extern struct {
     pub usingnamespace IntrinsicMap(AddrInfoMap, .AddrInfo);
 
     pub fn createFromAddrinfo(map_map: Map.Ptr, token: *Heap.AllocationToken, actor_id: u31, addrinfo: *std.os.addrinfo) AddrInfoMap.Ptr {
-        const sockaddr_memory = @ptrCast([*]u8, addrinfo.addr.?);
+        const sockaddr_memory: [*]u8 = @ptrCast(addrinfo.addr.?);
         const sockaddr_bytes_object = ByteArrayObject.createWithValues(map_map, token, actor_id, sockaddr_memory[0..addrinfo.addrlen]);
 
         const self = create(map_map, token);
@@ -40,7 +40,7 @@ pub const AddrInfoMap = extern struct {
 
     fn create(map_map: Map.Ptr, token: *Heap.AllocationToken) AddrInfoMap.Ptr {
         const memory = token.allocate(.Object, AddrInfoMap.requiredSizeForAllocation());
-        const self = @ptrCast(AddrInfoMap.Ptr, memory);
+        const self: AddrInfoMap.Ptr = @ptrCast(memory);
 
         self.init(map_map);
         return self;

--- a/src/runtime/objects/managed.zig
+++ b/src/runtime/objects/managed.zig
@@ -41,12 +41,13 @@ pub const FileDescriptor = packed struct(u62) {
     }
 
     pub fn fromValue(value: GenericValue) FileDescriptor {
-        const raw_value = value.asUnsignedInteger();
-        return @bitCast(FileDescriptor, @intCast(u62, raw_value));
+        const raw_value: u62 = @intCast(value.asUnsignedInteger());
+        return @bitCast(raw_value);
     }
 
     pub fn toValue(self: FileDescriptor) GenericValue {
-        return GenericValue.fromUnsignedInteger(@bitCast(u62, self));
+        const self_as_int: u62 = @bitCast(self);
+        return GenericValue.fromUnsignedInteger(self_as_int);
     }
 
     pub fn close(self: *FileDescriptor) void {
@@ -77,7 +78,7 @@ pub const Managed = extern struct {
 
     pub fn create(map_map: Map.Ptr, token: *Heap.AllocationToken, actor_id: u31, managed_type: ManagedType, value: GenericValue) !Managed.Ptr {
         const memory_area = token.allocate(.Object, requiredSizeForAllocation());
-        const self = @ptrCast(Managed.Ptr, memory_area);
+        const self: Managed.Ptr = @ptrCast(memory_area);
         self.init(actor_id, map_map, managed_type, value);
 
         try token.heap.markAddressAsNeedingFinalization(memory_area);
@@ -97,11 +98,11 @@ pub const Managed = extern struct {
     }
 
     fn setManagedType(self: Managed.Ptr, managed_type: ManagedType) void {
-        self.object.object_information.extra = @enumToInt(managed_type);
+        self.object.object_information.extra = @intFromEnum(managed_type);
     }
 
     pub fn getManagedType(self: Managed.Ptr) ManagedType {
-        return @intToEnum(ManagedType, self.object.object_information.extra);
+        return @enumFromInt(self.object.object_information.extra);
     }
 
     pub fn canFinalize(self: Managed.Ptr) bool {
@@ -131,7 +132,7 @@ pub const Managed = extern struct {
     }
 
     pub fn asObjectAddress(self: Managed.Ptr) [*]u64 {
-        return @ptrCast([*]u64, self);
+        return @ptrCast(self);
     }
 
     pub fn asValue(self: Managed.Ptr) GenericValue {

--- a/src/runtime/objects/method.zig
+++ b/src/runtime/objects/method.zig
@@ -45,10 +45,10 @@ pub const Method = extern struct {
             );
         }
 
-        const size = Method.requiredSizeForAllocation(@intCast(u8, assignable_slot_values.len));
+        const size = Method.requiredSizeForAllocation(@intCast(assignable_slot_values.len));
 
         var memory_area = token.allocate(.Object, size);
-        var self = @ptrCast(Method.Ptr, memory_area);
+        var self: Method.Ptr = @ptrCast(memory_area);
         self.init(actor_id, map);
         @memcpy(self.getAssignableSlots(), assignable_slot_values);
 
@@ -189,7 +189,7 @@ pub const MethodMap = extern struct {
         const size = MethodMap.requiredSizeForAllocation(total_slot_count);
 
         var memory_area = token.allocate(.Object, size);
-        var self = @ptrCast(MethodMap.Ptr, memory_area);
+        var self: MethodMap.Ptr = @ptrCast(memory_area);
         self.init(map_map, argument_slot_count, total_slot_count, is_inline_method, method_name, block, executable);
 
         try token.heap.markAddressAsNeedingFinalization(memory_area);
@@ -212,11 +212,13 @@ pub const MethodMap = extern struct {
     }
 
     fn setInlineMethod(self: MethodMap.Ptr, is_inline_method: bool) void {
-        @ptrCast(*MethodInformation, &self.base_map.slots.map.map_information.extra).is_inline = is_inline_method;
+        const method_info: *MethodInformation = @ptrCast(&self.base_map.slots.map.map_information.extra);
+        method_info.is_inline = is_inline_method;
     }
 
     fn isInlineMethod(self: MethodMap.Ptr) bool {
-        return @ptrCast(*MethodInformation, &self.base_map.slots.map.map_information.extra).is_inline;
+        const method_info: *MethodInformation = @ptrCast(&self.base_map.slots.map.map_information.extra);
+        return method_info.is_inline;
     }
 
     pub fn expectsActivationObjectAsReceiver(self: MethodMap.Ptr) bool {

--- a/src/runtime/primitives.zig
+++ b/src/runtime/primitives.zig
@@ -146,7 +146,7 @@ fn PrimitiveArguments(comptime primitive_name: []const u8) type {
                 return error.GetArgumentFailure;
             }
 
-            return @intCast(u64, value_as_integer);
+            return @intCast(value_as_integer);
         }
 
         // TODO: Figure out why stage2 explodes with this function being inline

--- a/src/runtime/primitives/actor.zig
+++ b/src/runtime/primitives/actor.zig
@@ -423,7 +423,7 @@ pub fn ActorYieldReason(context: *PrimitiveContext) !ExecutionResult {
     const arguments = context.getArguments("_ActorResume");
     const receiver = try arguments.getObject(PrimitiveContext.Receiver, .Actor);
     const actor = receiver.getActor();
-    return ExecutionResult.completion(Completion.initNormal(Value.fromUnsignedInteger(@enumToInt(actor.yield_reason))));
+    return ExecutionResult.completion(Completion.initNormal(Value.fromUnsignedInteger(@intFromEnum(actor.yield_reason))));
 }
 
 /// Yield this actor.

--- a/src/runtime/primitives/array.zig
+++ b/src/runtime/primitives/array.zig
@@ -25,7 +25,7 @@ pub fn ArrayCopySize_FillingExtrasWith(context: *PrimitiveContext) !ExecutionRes
     const size = try arguments.getInteger(0, .Unsigned);
     if (try context.wouldOverflow(usize, size, "size")) |result| return result;
 
-    const required_memory = array_object.ArrayMap.requiredSizeForAllocation() + array_object.Array.requiredSizeForAllocation(@intCast(usize, size));
+    const required_memory = array_object.ArrayMap.requiredSizeForAllocation() + array_object.Array.requiredSizeForAllocation(@intCast(size));
     var token = try context.vm.heap.getAllocation(required_memory);
     defer token.deinit();
 
@@ -37,7 +37,7 @@ pub fn ArrayCopySize_FillingExtrasWith(context: *PrimitiveContext) !ExecutionRes
         const receiver = try arguments.getObject(PrimitiveContext.Receiver, .Array);
         const filler = arguments.getValue(1);
 
-        const new_array_map = array_object.ArrayMap.create(context.vm.getMapMap(), &token, @intCast(usize, size));
+        const new_array_map = array_object.ArrayMap.create(context.vm.getMapMap(), &token, @intCast(size));
         const new_array = array_object.Array.createWithValues(&token, context.actor.id, new_array_map, receiver.getValues(), filler);
         return ExecutionResult.completion(Completion.initNormal(new_array.asValue()));
     }
@@ -70,7 +70,7 @@ pub fn ArrayAt(context: *PrimitiveContext) !ExecutionResult {
         );
     }
 
-    return ExecutionResult.completion(Completion.initNormal(array_values[@intCast(usize, position)]));
+    return ExecutionResult.completion(Completion.initNormal(array_values[@intCast(position)]));
 }
 
 /// Place the object in the second argument to the integer position in the first
@@ -107,7 +107,7 @@ pub fn ArrayAt_Put(context: *PrimitiveContext) !ExecutionResult {
         );
     }
 
-    array_values[@intCast(usize, position)] = new_value;
+    array_values[@intCast(position)] = new_value;
 
     if (receiver.object.object_information.reachability == .Global) {
         // Mark the object graph of new_value as globally reachable

--- a/src/runtime/primitives/byte_array.zig
+++ b/src/runtime/primitives/byte_array.zig
@@ -16,7 +16,7 @@ const PrimitiveContext = @import("../primitives.zig").PrimitiveContext;
 pub fn ByteArraySize(context: *PrimitiveContext) !ExecutionResult {
     const arguments = context.getArguments("_ByteArraySize");
     const receiver = try arguments.getObject(PrimitiveContext.Receiver, .ByteArray);
-    return ExecutionResult.completion(Completion.initNormal(Value.fromInteger(@intCast(i64, receiver.getValues().len))));
+    return ExecutionResult.completion(Completion.initNormal(Value.fromInteger(@intCast(receiver.getValues().len))));
 }
 
 /// Return a byte at the given (integer) position of the receiver, which is a
@@ -38,7 +38,7 @@ pub fn ByteAt(context: *PrimitiveContext) !ExecutionResult {
         ));
     }
 
-    return ExecutionResult.completion(Completion.initNormal(Value.fromInteger(values[@intCast(usize, position)])));
+    return ExecutionResult.completion(Completion.initNormal(Value.fromInteger(values[@intCast(position)])));
 }
 
 /// Place the second argument at the position given by the first argument on the
@@ -71,7 +71,7 @@ pub fn ByteAt_Put(context: *PrimitiveContext) !ExecutionResult {
         ));
     }
 
-    values[@intCast(usize, position)] = @intCast(u8, new_value);
+    values[@intCast(position)] = @intCast(new_value);
     return ExecutionResult.completion(Completion.initNormal(receiver.asValue()));
 }
 
@@ -97,7 +97,7 @@ pub fn ByteArrayCopySize_FillingExtrasWith(context: *PrimitiveContext) !Executio
     const filler = filler_contents[0];
 
     var token = try context.vm.heap.getAllocation(
-        ByteArrayObject.requiredSizeForAllocation(@intCast(usize, size)),
+        ByteArrayObject.requiredSizeForAllocation(@intCast(size)),
     );
     defer token.deinit();
 
@@ -106,8 +106,8 @@ pub fn ByteArrayCopySize_FillingExtrasWith(context: *PrimitiveContext) !Executio
 
     var values = receiver.getValues();
 
-    const new_byte_array = ByteArray.createUninitialized(&token, @intCast(usize, size));
-    const bytes_to_copy = @intCast(usize, std.math.min(size, values.len));
+    const new_byte_array = ByteArray.createUninitialized(&token, @intCast(size));
+    const bytes_to_copy: usize = @intCast(@min(size, values.len));
     @memcpy(new_byte_array.getValues()[0..bytes_to_copy], values[0..bytes_to_copy]);
 
     if (size > values.len) {

--- a/src/runtime/primitives/number.zig
+++ b/src/runtime/primitives/number.zig
@@ -94,7 +94,7 @@ pub fn IntShl(context: *PrimitiveContext) !ExecutionResult {
             // FIXME: These functions should be passed i62s in the first place,
             // but doing that requires making Value.fromInteger return 62-bit
             // integers.
-            const result: i64 = (receiver << @intCast(u6, term)) & ((@as(i64, 1) << 62) - 1);
+            const result: i64 = (receiver << @as(u6, @intCast(term))) & ((@as(i64, 1) << 62) - 1);
             return ExecutionResult.completion(Completion.initNormal(Value.fromInteger(result)));
         }
     }.op);
@@ -117,7 +117,7 @@ pub fn IntShr(context: *PrimitiveContext) !ExecutionResult {
             // FIXME: These functions should be passed i62s in the first place,
             // but doing that requires making Value.fromInteger return 62-bit
             // integers.
-            const result: i64 = (receiver >> @intCast(u6, term)) & ((@as(i64, 1) << 62) - 1);
+            const result: i64 = (receiver >> @as(u6, @intCast(term))) & ((@as(i64, 1) << 62) - 1);
             return ExecutionResult.completion(Completion.initNormal(Value.fromInteger(result)));
         }
     }.op);

--- a/src/runtime/primitives/object.zig
+++ b/src/runtime/primitives/object.zig
@@ -78,7 +78,7 @@ pub fn RemoveSlot_IfFail(context: *PrimitiveContext) !Completion {
                 .{},
             );
         },
-        else => return @errSetCast(Allocator.Error, err),
+        else => return @as(Allocator.Error, @errSetCast(err)),
     };
 
     if (!did_remove_slot) {

--- a/src/runtime/primitives/system_call.zig
+++ b/src/runtime/primitives/system_call.zig
@@ -16,6 +16,7 @@ const FileDescriptor = @import("../objects/managed.zig").FileDescriptor;
 const ByteArrayObject = @import("../objects/byte_array.zig").ByteArray;
 const value_inspector = @import("../value_inspector.zig");
 const addrinfo_object = @import("../objects/intrinsic/addrinfo.zig");
+const exceedsBoundsOf = @import("../../utility/bounds_check.zig").exceedsBoundsOf;
 const AddrInfoObject = addrinfo_object.AddrInfo;
 const AddrInfoMap = addrinfo_object.AddrInfoMap;
 
@@ -88,7 +89,16 @@ pub fn Read_BytesInto_AtOffset_From_IfFail(context: *PrimitiveContext) !Executio
     const arguments = context.getArguments("_Read:BytesInto:AtOffset:From:IfFail:");
     const bytes_to_read = try arguments.getInteger(0, .Unsigned);
     const byte_array = try arguments.getObject(1, .ByteArray);
-    const offset: usize = @intCast(try arguments.getInteger(2, .Unsigned));
+    const offset_int = try arguments.getInteger(2, .Unsigned);
+    if (exceedsBoundsOf(offset_int, usize)) {
+        return ExecutionResult.completion(try Completion.initRuntimeError(
+            context.vm,
+            context.source_range,
+            "Offset argument is larger than the maximum value of usize",
+            .{},
+        ));
+    }
+    const offset: usize = @intCast(offset_int);
     const fd = try arguments.getObject(3, .Managed);
     const failure_block = arguments.getValue(4);
 
@@ -148,7 +158,16 @@ pub fn Write_BytesFrom_AtOffset_Into_IfFail(context: *PrimitiveContext) !Executi
     const arguments = context.getArguments("_Write:BytesFrom:AtOffset:Into:IfFail:");
     const bytes_to_write = try arguments.getInteger(0, .Unsigned);
     const byte_array = try arguments.getObject(1, .ByteArray);
-    const offset = try arguments.getInteger(2, .Unsigned);
+    const offset_int = try arguments.getInteger(2, .Unsigned);
+    if (exceedsBoundsOf(offset_int, usize)) {
+        return ExecutionResult.completion(try Completion.initRuntimeError(
+            context.vm,
+            context.source_range,
+            "Offset argument is larger than the maximum value of usize",
+            .{},
+        ));
+    }
+    const offset: usize = @intCast(offset_int);
     const fd = try arguments.getObject(3, .Managed);
     const failure_block = arguments.getValue(4);
 

--- a/src/runtime/slot.zig
+++ b/src/runtime/slot.zig
@@ -118,7 +118,7 @@ const SlotProperties = packed struct {
     }
 
     pub fn getHash(self: SlotProperties) u32 {
-        return @intCast(u32, self.properties.asUnsignedInteger() >> 30);
+        return @intCast(self.properties.asUnsignedInteger() >> 30);
     }
 };
 
@@ -225,7 +225,7 @@ pub const Slot = packed struct {
             std.debug.assert(self.properties.isIndexAssigned());
         }
 
-        return @intCast(u8, self.value.asUnsignedInteger());
+        return @intCast(self.value.asUnsignedInteger());
     }
 
     pub fn getHash(self: Slot) u32 {
@@ -390,7 +390,7 @@ pub const Slot = packed struct {
 
             if (previous_slot.isAssignable()) {
                 const overwritten_assignable_slot_index = previous_slot.value.asUnsignedInteger();
-                _ = assignable_slot_values.orderedRemove(@intCast(usize, overwritten_assignable_slot_index));
+                _ = assignable_slot_values.orderedRemove(@intCast(overwritten_assignable_slot_index));
 
                 // Go through all the previous slots, and subtract 1 from all
                 // the slots which have assignable slot indices larger than the
@@ -438,12 +438,12 @@ pub const Slot = packed struct {
         } else if (self.isArgument()) {
             std.debug.assert(argument_slot_index.* < AstGen.MaximumArguments);
 
-            _ = current_slot_ptr.assignIndex(@intCast(u8, argument_slot_index.*));
+            _ = current_slot_ptr.assignIndex(@intCast(argument_slot_index.*));
             argument_slot_index.* += 1;
         } else if (self.isAssignable()) {
             std.debug.assert(assignable_slot_index.* + argument_slot_index.* < AstGen.MaximumAssignableSlots);
 
-            const value = current_slot_ptr.assignIndex(@intCast(u8, assignable_slot_index.*));
+            const value = current_slot_ptr.assignIndex(@intCast(assignable_slot_index.*));
             assignable_slot_values.appendAssumeCapacity(value);
             assignable_slot_index.* += 1;
         }

--- a/src/runtime/value.zig
+++ b/src/runtime/value.zig
@@ -189,7 +189,8 @@ pub fn PointerValueAlignment(comptime T: type, comptime alignment: ?u29) type {
         }
 
         pub fn get(self: Self) PointerT {
-            return @ptrFromInt(self.value.asUnsignedInteger());
+            const self_int: usize = @intCast(self.value.asUnsignedInteger());
+            return @ptrFromInt(self_int);
         }
     };
 }

--- a/src/utility/bounds_check.zig
+++ b/src/utility/bounds_check.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+
+pub fn exceedsBoundsOf(value: anytype, comptime T: type) bool {
+    const value_type_info = @typeInfo(@TypeOf(value));
+    const target_type_info = @typeInfo(T);
+
+    if (value_type_info.Int.signedness != target_type_info.Int.signedness)
+        @compileError("Can't bounds check for types of different signedness");
+
+    if (value_type_info.Int.bits < target_type_info.Int.bits)
+        return false;
+
+    // Prevent triggering UB ourselves by using the largest type between the two.
+    const PeerType = @TypeOf(value, @as(T, undefined));
+
+    if (@as(PeerType, value) > @as(PeerType, std.math.maxInt(T)))
+        return true;
+
+    // The check above is sufficient for unsigned values, but not signed ones.
+    if (value_type_info.Int.signedness != .signed)
+        return false;
+
+    if (@as(PeerType, value) < @as(PeerType, std.math.minInt(T)))
+        return true;
+
+    return false;
+}

--- a/src/utility/hash.zig
+++ b/src/utility/hash.zig
@@ -114,5 +114,5 @@ pub fn stringHash(string: []const u8) u32 {
         power = if (i < powers.len - 1) powers[i + 1] else ((power * P) % M);
     }
 
-    return @intCast(u32, hash_value);
+    return @intCast(hash_value);
 }


### PR DESCRIPTION
Use proper usize type for lengths

This PR changes the used integer types to `usize` for cases where it should be platform dependent, in order to compile `zigself` for other platforms like `armv7`.

Depends on #25.